### PR TITLE
feat: add `<ShowcaseGitHub>` component

### DIFF
--- a/docs/src/content/docs/components/github.mdx
+++ b/docs/src/content/docs/components/github.mdx
@@ -1,0 +1,98 @@
+---
+title: GitHub
+description: Learn how to use the GitHub component to showcase GitHub repositories and users.
+sidebar:
+  order: 7
+---
+
+The `<ShowcaseGitHub>` component can be used to showcase GitHub repositories or users.
+
+## Import
+
+```js
+import { ShowcaseGitHub } from 'starlight-showcases'
+```
+
+## Usage
+
+### GitHub Repository
+
+Specify the GitHub repository to display using the `avatar`, `description`, `env`, `repo`.
+
+```mdx title="src/content/docs/showcase.mdx"
+import { ShowcaseGitHub } from 'starlight-showcases'
+
+<ShowcaseGitHub
+  avatar="494699"
+  description="Discover the Starlight Showcases components in action."
+  env="HiDeoo"
+  repo="starlight-showcases"
+/>
+```
+
+The above code generates the following on the page:
+
+import { ShowcaseGitHub } from 'starlight-showcases'
+
+<ShowcaseGitHub
+  avatar="494699"
+  description="Discover the Starlight Showcases components in action."
+  env="HiDeoo"
+  repo="starlight-showcases"
+/>
+
+### GitHub User
+
+Specify the GitHub user to display using the `avatar`, `description`, `user`.
+
+```mdx title="src/content/docs/showcase.mdx"
+import { ShowcaseGitHub } from 'starlight-showcases'
+
+<ShowcaseGitHub
+  avatar="10137"
+  description="Hi, I'm @ghost! I take the place of user accounts that have been deleted. :ghost:"
+  user="ghost"
+/>
+```
+
+The above code generates the following on the page:
+
+<ShowcaseGitHub
+  avatar="10137"
+  description="Hi, I'm @ghost! I take the place of user accounts that have been deleted. :ghost:"
+  user="ghost"
+/>
+
+## Props
+
+The `<ShowcaseGitHub>` component accepts the following props:
+
+### `avatar`
+
+**type:** `string`
+
+The GitHub user avatar ID.
+
+### `description`
+
+**type:** `string`
+
+The GitHub repository or user description.
+
+### `env`
+
+**type:** `string`
+
+The GitHub environment (user or organization).
+
+### `repo`
+
+**type:** `string`
+
+The GitHub repository name.
+
+### `user`
+
+**type:** `string`
+
+The GitHub user name.

--- a/docs/src/content/docs/demo.mdx
+++ b/docs/src/content/docs/demo.mdx
@@ -151,3 +151,20 @@ import { ShowcaseQuote } from 'starlight-showcases'
     },
   ]}
 />
+
+## GitHub
+
+import { ShowcaseGitHub } from 'starlight-showcases'
+
+<ShowcaseGitHub
+  avatar="494699"
+  description="Discover the Starlight Showcases components in action."
+  env="HiDeoo"
+  repo="starlight-showcases"
+/>
+
+<ShowcaseGitHub
+  avatar="10137"
+  description="Hi, I'm @ghost! I take the place of user accounts that have been deleted. :ghost:"
+  user="ghost"
+/>

--- a/packages/starlight-showcases/components/ShowcaseGitHub.astro
+++ b/packages/starlight-showcases/components/ShowcaseGitHub.astro
@@ -1,0 +1,130 @@
+---
+export type ShowcaseGitHubProps = Props
+
+interface Props {
+  avatar?: string
+  description?: string
+  env?: string
+  repo?: string
+  user?: string
+}
+
+const { avatar, description, env, repo, user } = Astro.props
+---
+
+<div class="not-content sl-flex">
+  <div class="starlight-showcases-github-card">
+    <div class="starlight-showcases-github-card-body">
+      <div class="starlight-showcases-github-card-body-header">
+        <h2 class="starlight-showcases-github-card-title">
+          {
+            env && repo && (
+              <a class="starlight-showcases-github-card-title-link" href={`https://github.com/${env}/${repo}`}>
+                <span class="starlight-showcases-github-card-title-link-env">{env}/</span>
+                <br />
+                {repo}
+              </a>
+            )
+          }
+          {
+            user && (
+              <a class="starlight-showcases-github-card-title-link" href={`https://github.com/${user}`}>
+                {user}
+              </a>
+            )
+          }
+        </h2>
+        {
+          avatar && (
+            <img
+              class="starlight-showcases-github-card-avatar"
+              src={`https://avatars.githubusercontent.com/u/${avatar}?v=4`}
+              aria-hidden="true"
+              alt=""
+            />
+          )
+        }
+      </div>
+      {description && <p>{description}</p>}
+    </div>
+  </div>
+</div>
+
+<style>
+  .starlight-showcases-github-card {
+    position: relative;
+    border: none;
+    border-radius: 0.5rem;
+    box-shadow: var(--sl-shadow-sm);
+    width: 100%;
+  }
+
+  @media screen and (min-width: 480px) {
+    .starlight-showcases-github-card {
+      border: 1px solid var(--sl-color-gray-5);
+    }
+  }
+
+  .starlight-showcases-github-card-body {
+    padding: 0;
+    list-style-type: none;
+  }
+
+  @media screen and (min-width: 480px) {
+    .starlight-showcases-github-card-body {
+      padding: 2rem;
+    }
+  }
+
+  .starlight-showcases-github-card-body-header {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .starlight-showcases-github-card-title {
+    font-size: var(--sl-text-h3);
+    line-height: var(--sl-line-height-headings);
+    color: var(--sl-color-white);
+  }
+
+  .starlight-showcases-github-card-title-link {
+    font-weight: bold;
+    word-break: break-all;
+    color: var(--sl-color-white);
+    text-decoration: inherit;
+  }
+
+  .starlight-showcases-github-card-title-link:after {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    content: '';
+  }
+
+  .starlight-showcases-github-card-title-link:hover {
+    text-decoration: underline;
+  }
+
+  .starlight-showcases-github-card-title-link-env {
+    max-width: 50px;
+    font-weight: normal;
+  }
+
+  .starlight-showcases-github-card-title-link-repo {
+    font-weight: bold;
+    max-width: 50px;
+  }
+
+  .starlight-showcases-github-card-avatar {
+    width: 50px;
+    height: 50px;
+    border-radius: 0.75rem;
+  }
+
+  @media screen and (min-width: 480px) {
+    .starlight-showcases-github-card-avatar {
+      width: 60px;
+      height: 60px;
+    }
+  }
+</style>

--- a/packages/starlight-showcases/index.ts
+++ b/packages/starlight-showcases/index.ts
@@ -4,3 +4,4 @@ export { default as ShowcaseImage, type ShowcaseImageProps } from './components/
 export { default as ShowcaseQuote, type ShowcaseQuoteProps } from './components/ShowcaseQuote.astro'
 export { default as ShowcaseYouTube, type ShowcaseYouTubeProps } from './components/ShowcaseYouTube.astro'
 export { default as ShowcaseTwitter, type ShowcaseTwitterProps } from './components/ShowcaseTwitter.astro'
+export { default as ShowcaseGitHub, type ShowcaseGitHubProps } from './components/ShowcaseGitHub.astro'


### PR DESCRIPTION
**Describe the pull request**

This PR adds a new component named `<ShowcaseGitHub>` allowing to display a GitHub repository or user profile in a showcase.

This component is not retrieving data from the GitHub API, it is just a pure rendering component.

**Why**

As discussed together, this could be an interesting new component in `starlight-showcases`.

**How**

The implementation is based on the other showcase components, with a list of props to customize the display.

The current implementation is a single component that can display either a repository or a user profile. It has the advantage of being simple to maintain, but it could be split into two components if needed for better separation of concerns, and understandability for the users (a separate stricter interface).

The implementation is still WIP as there are some improvements to be made, this first version is primarily based on the implementation I have in another project.

Few things to tackle/decide together:
- [ ] Does the hover rendering need to be the same as the one used for the media cards?
- [ ] Define whether we want a special rendering at some breakpoints
- [ ] Not necessarily to do in a first version but hashtags in descriptions could be actual links to GitHub users (see "ghost" card)
- [ ] Maybe drop the ":ghost:" text from the description, as it's not rendered anyway; or could be replaced by copying/pasting the emoji directly, for instance.

**How to retrieve description and avatar automatically?**

This first version doesn't get the data automatically. We could change the way it works by doing:
- `<ShowcaseGitHubUser login />`
- `<ShowcaseGitHubRepo owner repo />`

And then call the GitHub public API when the rendering is built:
- GET https://api.github.com/users/ghost (user)
- GET https://api.github.com/repos/hideoo/starlight-showcases (project)

Please note that the primary rate limit for unauthenticated requests is 60 requests per hour. (source: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28)

**Screenshots**

![Screenshot 2024-07-15 at 16 28 45](https://github.com/user-attachments/assets/4110e817-581e-46c5-b215-f8234d879971)
![Screenshot 2024-07-15 at 16 28 38](https://github.com/user-attachments/assets/03aed243-44a8-45c3-b759-01b92b3c93f0)



